### PR TITLE
fix icon size

### DIFF
--- a/packages/panda/src/theme/recipes/command.ts
+++ b/packages/panda/src/theme/recipes/command.ts
@@ -113,8 +113,8 @@ export const command = defineSlotRecipe({
           w: 'full',
         },
         itemIndicator: {
-          h: '{sizes.icon.md}',
-          w: '{sizes.icon.md}',
+          h: '{sizes.icon.sm}',
+          w: '{sizes.icon.sm}',
         },
       },
       floating: {


### PR DESCRIPTION
accidentally committed this change previously while experimenting with standardizing icon sizes across recipes and semantic tokens